### PR TITLE
refactor: Use environment variables for TikTok OAuth credentials

### DIFF
--- a/src/pages/api/tiktok/callback.ts
+++ b/src/pages/api/tiktok/callback.ts
@@ -1,0 +1,107 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+// Server-side environment variables.
+// Ensure TIKTOK_CLIENT_KEY and TIKTOK_CLIENT_SECRET are set in your environment.
+// For local development, you can add them to a .env.local file:
+// TIKTOK_CLIENT_KEY=your_actual_client_key
+// TIKTOK_CLIENT_SECRET=your_actual_client_secret
+const TIKTOK_CLIENT_KEY = process.env.TIKTOK_CLIENT_KEY;
+const TIKTOK_CLIENT_SECRET = process.env.TIKTOK_CLIENT_SECRET;
+// TODO: Ensure this matches the redirect URI configured in your TikTok app and on the auth page
+const REDIRECT_URI = 'https://www.thejoydigi.com/api/tiktok/callback';
+
+type TikTokTokenResponse = {
+  access_token?: string;
+  refresh_token?: string;
+  error?: string;
+  error_description?: string;
+  open_id?: string;
+  scope?: string;
+  expires_in?: number;
+  refresh_expires_in?: number;
+  token_type?: string;
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (!TIKTOK_CLIENT_KEY || !TIKTOK_CLIENT_SECRET) {
+    console.error('Missing TikTok server-side environment variables: TIKTOK_CLIENT_KEY or TIKTOK_CLIENT_SECRET');
+    return res.status(500).json({ message: 'Server configuration error: TikTok credentials not set.' });
+  }
+
+  const { code, state, error, error_description } = req.query;
+
+  if (error) {
+    console.error(`TikTok Authorization Error: ${error} - ${error_description}`);
+    return res.status(400).json({ 
+      message: `TikTok Authorization Failed: ${error_description || error}` 
+    });
+  }
+
+  // Retrieve stored CSRF state - In a real app, you might store this in a session
+  // For this example, we assume the auth page used localStorage and we can't directly access it here.
+  // In a real scenario, the CSRF token should be passed to the server when the auth process starts,
+  // stored in a user session (e.g., httpOnly cookie), and then compared here.
+  // For simplicity, this example won't have robust CSRF verification on the server-side callback
+  // without implementing a session mechanism. The auth page DOES create and store it in localStorage.
+  // A robust solution would involve:
+  // 1. Client generates CSRF, stores it in a cookie, and sends it in the state.
+  // 2. Server reads cookie CSRF, compares with state CSRF.
+  // Or:
+  // 1. Server generates CSRF, stores in session (httpOnly cookie), sends to client to include in state.
+  // 2. Client sends state (inc. CSRF) to TikTok.
+  // 3. TikTok redirects back with state. Server compares state's CSRF with session CSRF.
+
+  // const storedState = req.cookies.tiktok_csrf_state; // Example if using cookies
+  // if (!state || state !== storedState) {
+  //   return res.status(403).json({ message: 'CSRF token mismatch. Invalid state.' });
+  // }
+
+  if (!code) {
+    return res.status(400).json({ message: 'Authorization code is missing.' });
+  }
+
+  const params = new URLSearchParams();
+  params.append('client_key', TIKTOK_CLIENT_KEY);
+  params.append('client_secret', TIKTOK_CLIENT_SECRET);
+  params.append('code', code as string);
+  params.append('grant_type', 'authorization_code');
+  params.append('redirect_uri', REDIRECT_URI);
+
+  try {
+    const response = await fetch('https://open.tiktokapis.com/v2/oauth/token/', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: params,
+    });
+
+    const data: TikTokTokenResponse = await response.json();
+
+    if (!response.ok || data.error) {
+      console.error('TikTok Token API Error:', data);
+      return res.status(response.status || 500).json({ 
+        message: `Failed to obtain access token: ${data.error_description || data.error || 'Unknown error'}` 
+      });
+    }
+
+    // Successfully obtained tokens
+    // Redirect to a page to display tokens or handle them as needed
+    // For this example, redirecting to a new page with tokens in query params
+    // IMPORTANT: In production, exposing tokens in URL is not recommended.
+    // They should be handled server-side or stored securely (e.g., httpOnly cookies).
+    const { access_token, refresh_token } = data;
+    if (access_token && refresh_token) {
+      res.redirect(`/tiktok-tokens?access_token=${encodeURIComponent(access_token)}&refresh_token=${encodeURIComponent(refresh_token)}`);
+    } else {
+      res.status(500).json({ message: 'Access token or refresh token not found in response.' });
+    }
+
+  } catch (err: any) {
+    console.error('Internal server error during token exchange:', err);
+    return res.status(500).json({ message: 'Internal Server Error', details: err.message });
+  }
+}

--- a/src/pages/tiktok-auth.tsx
+++ b/src/pages/tiktok-auth.tsx
@@ -1,0 +1,72 @@
+import Head from 'next/head';
+import { useEffect, useState } from 'react';
+
+// Ensure you have NEXT_PUBLIC_TIKTOK_CLIENT_KEY and NEXT_PUBLIC_TIKTOK_SCOPES 
+// set in your environment (e.g., .env.local file for development).
+// Example .env.local:
+// NEXT_PUBLIC_TIKTOK_CLIENT_KEY=your_actual_client_key
+// NEXT_PUBLIC_TIKTOK_SCOPES=user.info.basic,user.account.type
+
+// Read from environment variables
+const TIKTOK_CLIENT_KEY = process.env.NEXT_PUBLIC_TIKTOK_CLIENT_KEY;
+// Read from environment variables with a default fallback
+const TIKTOK_SCOPES = process.env.NEXT_PUBLIC_TIKTOK_SCOPES || 'user.info.basic';
+// TODO: Ensure this matches the redirect URI configured in your TikTok app
+const REDIRECT_URI = 'https://www.thejoydigi.com/api/tiktok/callback';
+
+export default function TikTokAuthPage() {
+  const [csrfState, setCsrfState] = useState('');
+
+  useEffect(() => {
+    // Generate a random string for CSRF protection
+    const randomString = Math.random().toString(36).substring(2);
+    setCsrfState(randomString);
+    // Store it in localStorage to verify on callback
+    localStorage.setItem('tiktok_csrf_state', randomString);
+  }, []);
+
+  const handleLogin = () => {
+    if (!TIKTOK_CLIENT_KEY || !TIKTOK_SCOPES) {
+      alert('TikTok client key or scopes are not configured. Please set NEXT_PUBLIC_TIKTOK_CLIENT_KEY and NEXT_PUBLIC_TIKTOK_SCOPES environment variables.');
+      console.error('Missing TikTok environment variables: NEXT_PUBLIC_TIKTOK_CLIENT_KEY or NEXT_PUBLIC_TIKTOK_SCOPES');
+      return;
+    }
+
+    if (!csrfState) {
+      alert('CSRF token not generated yet. Please wait a moment and try again.');
+      return;
+    }
+
+    let url = 'https://www.tiktok.com/v2/auth/authorize/';
+    url += `?client_key=${TIKTOK_CLIENT_KEY}`;
+    url += `&scope=${TIKTOK_SCOPES}`;
+    url += '&response_type=code';
+    url += `&redirect_uri=${encodeURIComponent(REDIRECT_URI)}`;
+    url += `&state=${csrfState}`;
+    // Optional: Set to 1 to always show the authorization page, even if the user is already logged in
+    // url += '&disable_auto_auth=1';
+
+    window.location.href = url;
+  };
+
+  return (
+    <>
+      <Head>
+        <title>TikTok Authorization</title>
+        <meta name="description" content="Authorize TikTok to get access tokens" />
+      </Head>
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', minHeight: '100vh', fontFamily: 'sans-serif' }}>
+        <h1>Authorize with TikTok</h1>
+        <p>Click the button below to authorize our application with your TikTok account.</p>
+        <button 
+          onClick={handleLogin} 
+          disabled={!csrfState}
+          style={{ padding: '10px 20px', fontSize: '16px', cursor: 'pointer', backgroundColor: '#0070f3', color: 'white', border: 'none', borderRadius: '5px' }}
+        >
+          Continue with TikTok
+        </button>
+        {!csrfState && <p style={{color: 'red', marginTop: '10px'}}>Generating security token...</p>}
+      </div>
+    </>
+  );
+}

--- a/src/pages/tiktok-tokens.tsx
+++ b/src/pages/tiktok-tokens.tsx
@@ -1,0 +1,111 @@
+import Head from 'next/head';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+export default function TikTokTokensPage() {
+  const router = useRouter();
+  const [accessToken, setAccessToken] = useState('');
+  const [refreshToken, setRefreshToken] = useState('');
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    if (router.isReady) {
+      const { access_token, refresh_token, error } = router.query;
+
+      if (error) {
+        setMessage(`Error: ${error}`);
+        return;
+      }
+
+      if (access_token && typeof access_token === 'string') {
+        setAccessToken(access_token);
+      } else {
+        if (!error) setMessage(prev => prev + 'Access token not found. ');
+      }
+
+      if (refresh_token && typeof refresh_token === 'string') {
+        setRefreshToken(refresh_token);
+      } else {
+         if (!error) setMessage(prev => prev + 'Refresh token not found.');
+      }
+    }
+  }, [router.isReady, router.query]);
+
+  const copyToClipboard = (text: string, tokenName: string) => {
+    if (!navigator.clipboard) {
+      setMessage('Clipboard API not available. Please copy manually.');
+      return;
+    }
+    navigator.clipboard.writeText(text)
+      .then(() => setMessage(`${tokenName} copied to clipboard!`))
+      .catch(err => {
+        console.error('Failed to copy text: ', err);
+        setMessage(`Failed to copy ${tokenName}. Please copy manually.`);
+      });
+  };
+
+  return (
+    <>
+      <Head>
+        <title>TikTok Tokens</title>
+        <meta name="description" content="Display TikTok Access and Refresh Tokens" />
+      </Head>
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', minHeight: '100vh', fontFamily: 'sans-serif', padding: '20px' }}>
+        <h1>TikTok Tokens</h1>
+        {message && <p style={{ color: message.startsWith('Error') || message.startsWith('Failed') ? 'red' : 'green' }}>{message}</p>}
+
+        {accessToken && (
+          <div style={{ margin: '10px 0', width: '100%', maxWidth: '600px' }}>
+            <h2>Access Token</h2>
+            <textarea
+              readOnly
+              value={accessToken}
+              rows={5}
+              style={{ width: '100%', padding: '10px', marginBottom: '5px', border: '1px solid #ccc', borderRadius: '4px', fontFamily: 'monospace' }}
+            />
+            <button 
+              onClick={() => copyToClipboard(accessToken, 'Access Token')}
+              style={{ padding: '8px 15px', cursor: 'pointer' }}
+            >
+              Copy Access Token
+            </button>
+          </div>
+        )}
+
+        {refreshToken && (
+          <div style={{ margin: '10px 0', width: '100%', maxWidth: '600px' }}>
+            <h2>Refresh Token</h2>
+            <textarea
+              readOnly
+              value={refreshToken}
+              rows={5}
+              style={{ width: '100%', padding: '10px', marginBottom: '5px', border: '1px solid #ccc', borderRadius: '4px', fontFamily: 'monospace' }}
+            />
+            <button 
+              onClick={() => copyToClipboard(refreshToken, 'Refresh Token')}
+              style={{ padding: '8px 15px', cursor: 'pointer' }}
+            >
+              Copy Refresh Token
+            </button>
+          </div>
+        )}
+
+        {!accessToken && !refreshToken && !router.query.error && (
+          <p>Loading tokens or no tokens provided...</p>
+        )}
+
+        <p style={{ marginTop: '20px', fontSize: '0.9em', color: '#555', textAlign: 'center' }}>
+          <strong>Security Reminder:</strong> These tokens grant access to your TikTok account.
+          Do not share them. For production applications, tokens should be stored securely
+          and not displayed directly to users in this manner.
+        </p>
+        <button 
+            onClick={() => router.push('/tiktok-auth')}
+            style={{ marginTop: '20px', padding: '10px 20px', cursor: 'pointer' }}
+        >
+            Authorize Again
+        </button>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
Updates the TikTok OAuth implementation to:
- Use a fixed REDIRECT_URI: `https://www.thejoydigi.com/api/tiktok/callback`.
- Source TIKTOK_CLIENT_KEY and TIKTOK_SCOPES from NEXT_PUBLIC_ environment variables in `tiktok-auth.tsx` (client-side).
- Source TIKTOK_CLIENT_KEY and TIKTOK_CLIENT_SECRET from environment variables in `api/tiktok/callback.ts` (server-side).

This change improves security and configurability by removing hardcoded credentials and allowing them to be set through the environment. Added necessary checks and comments for these variables.