### PR TITLE
refactor: Use consistent env var for TikTok client key

### DIFF
--- a/src/pages/api/tiktok/callback.ts
+++ b/src/pages/api/tiktok/callback.ts
@@ -1,11 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 // Server-side environment variables.
-// Ensure TIKTOK_CLIENT_KEY and TIKTOK_CLIENT_SECRET are set in your environment.
+// Ensure NEXT_PUBLIC_TIKTOK_CLIENT_KEY and TIKTOK_CLIENT_SECRET are set in your environment.
+// NEXT_PUBLIC_TIKTOK_CLIENT_KEY is used here as it's also used client-side and simplifies setup.
 // For local development, you can add them to a .env.local file:
-// TIKTOK_CLIENT_KEY=your_actual_client_key
+// NEXT_PUBLIC_TIKTOK_CLIENT_KEY=your_actual_client_key
 // TIKTOK_CLIENT_SECRET=your_actual_client_secret
-const TIKTOK_CLIENT_KEY = process.env.TIKTOK_CLIENT_KEY;
+const TIKTOK_CLIENT_KEY = process.env.NEXT_PUBLIC_TIKTOK_CLIENT_KEY;
 const TIKTOK_CLIENT_SECRET = process.env.TIKTOK_CLIENT_SECRET;
 // TODO: Ensure this matches the redirect URI configured in your TikTok app and on the auth page
 const REDIRECT_URI = 'https://www.thejoydigi.com/api/tiktok/callback';
@@ -27,7 +28,7 @@ export default async function handler(
   res: NextApiResponse
 ) {
   if (!TIKTOK_CLIENT_KEY || !TIKTOK_CLIENT_SECRET) {
-    console.error('Missing TikTok server-side environment variables: TIKTOK_CLIENT_KEY or TIKTOK_CLIENT_SECRET');
+    console.error('Missing TikTok server-side environment variables: NEXT_PUBLIC_TIKTOK_CLIENT_KEY or TIKTOK_CLIENT_SECRET');
     return res.status(500).json({ message: 'Server configuration error: TikTok credentials not set.' });
   }
 


### PR DESCRIPTION
Updates `api/tiktok/callback.ts` to use `NEXT_PUBLIC_TIKTOK_CLIENT_KEY` for the TikTok client key. This aligns with the environment variable name used in the client-side code (`tiktok-auth.tsx`).

The `TIKTOK_CLIENT_SECRET` remains as a separate, non-prefixed environment variable as it is server-only.

This change simplifies environment variable configuration by using the same variable name for the client key across both client and server contexts.