### PR TITLE
fix: Resolve duplicate property in tiktok-content styles

### DIFF
--- a/src/pages/tiktok-content.tsx
+++ b/src/pages/tiktok-content.tsx
@@ -177,7 +177,6 @@ const TikTokContentPage: React.FC = () => {
               textAlign: 'center',
               minWidth: '320px', // Slightly wider
             maxWidth: '480px', // Max width
-            minWidth: '320px',
             boxSizing: 'border-box',
             }}>
               {dialogStep === 'confirm' && (


### PR DESCRIPTION
This commit fixes a build error in `src/pages/tiktok-content.tsx` caused by a duplicate `minWidth` property in the style object for the main dialog container.

The redundant property has been removed, and I've confirmed that the page now loads correctly and dialog functionality remains intact.