### PR TITLE
Add interest topics manager

### DIFF
--- a/ENVIRONMENT_VARIABLES.md
+++ b/ENVIRONMENT_VARIABLES.md
@@ -41,3 +41,15 @@
     ```
     NEXT_PUBLIC_TIKTOK_SCOPES=user.info.basic,video.upload
     ```
+
+## Interest Topics Management (S3)
+
+These variables configure the AWS S3 bucket used to store the `interests.json` file.
+
+```
+AWS_ACCESS_KEY_ID=your_access_key
+AWS_SECRET_ACCESS_KEY=your_secret_key
+AWS_REGION=us-east-1
+S3_BUCKET_NAME=your_bucket
+INTERESTS_KEY=interests.json # optional
+```

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This is the official website for TheJoyDigi, providing innovative IT solutions t
 - Blog section with industry insights and digital transformation guides
 - Contact form for business inquiries
 - Mobile-friendly design
+- Hidden admin page for managing interest topics stored in S3
 
 ## Tech Stack
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "react-icons": "^5.5.0",
     "react-markdown": "^9.0.1",
     "sharp": "^0.33.2",
-    "slugify": "^1.6.6"
+    "slugify": "^1.6.6",
+    "@aws-sdk/client-s3": "^3.550.0"
   },
   "devDependencies": {
     "@google/generative-ai": "^0.24.0",

--- a/src/pages/api/interests.ts
+++ b/src/pages/api/interests.ts
@@ -1,0 +1,75 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { S3Client, GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
+
+const region = process.env.AWS_REGION;
+const bucket = process.env.S3_BUCKET_NAME;
+const key = process.env.INTERESTS_KEY || 'interests.json';
+
+const s3 = new S3Client({ region });
+
+async function loadTopics(): Promise<string[]> {
+  try {
+    const resp = await s3.send(
+      new GetObjectCommand({ Bucket: bucket, Key: key })
+    );
+    const body = await resp.Body?.transformToString();
+    if (!body) return [];
+    const parsed = JSON.parse(body);
+    return Array.isArray(parsed.topics) ? parsed.topics : [];
+  } catch (err: any) {
+    if (err.name === 'NoSuchKey') return [];
+    throw err;
+  }
+}
+
+async function saveTopics(topics: string[]) {
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: JSON.stringify({ topics }),
+      ContentType: 'application/json'
+    })
+  );
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (!bucket || !region) {
+    return res.status(500).json({ message: 'S3 configuration missing' });
+  }
+
+  try {
+    if (req.method === 'GET') {
+      const topics = await loadTopics();
+      return res.status(200).json({ topics });
+    }
+
+    if (req.method === 'POST') {
+      const { topic } = req.body;
+      if (!topic || typeof topic !== 'string') {
+        return res.status(400).json({ message: 'Invalid topic' });
+      }
+      const topics = await loadTopics();
+      if (!topics.includes(topic)) topics.push(topic);
+      await saveTopics(topics);
+      return res.status(200).json({ topics });
+    }
+
+    if (req.method === 'DELETE') {
+      const { topic } = req.body;
+      if (!topic || typeof topic !== 'string') {
+        return res.status(400).json({ message: 'Invalid topic' });
+      }
+      const topics = await loadTopics();
+      const updated = topics.filter(t => t !== topic);
+      await saveTopics(updated);
+      return res.status(200).json({ topics: updated });
+    }
+
+    res.setHeader('Allow', 'GET,POST,DELETE');
+    return res.status(405).end('Method Not Allowed');
+  } catch (err) {
+    console.error('Interests API error:', err);
+    return res.status(500).json({ message: 'Internal Server Error' });
+  }
+}

--- a/src/pages/manage-interests.tsx
+++ b/src/pages/manage-interests.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react';
+import MainLayout from './_layouts';
+
+export default function ManageInterests() {
+  const [topics, setTopics] = useState<string[]>([]);
+  const [newTopic, setNewTopic] = useState('');
+
+  const fetchTopics = async () => {
+    try {
+      const res = await fetch('/api/interests');
+      if (res.ok) {
+        const data = await res.json();
+        setTopics(data.topics || []);
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  useEffect(() => {
+    fetchTopics();
+  }, []);
+
+  const addTopic = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!newTopic.trim()) return;
+    await fetch('/api/interests', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ topic: newTopic.trim() })
+    });
+    setNewTopic('');
+    fetchTopics();
+  };
+
+  const removeTopic = async (topic: string) => {
+    await fetch('/api/interests', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ topic })
+    });
+    fetchTopics();
+  };
+
+  return (
+    <MainLayout title="Manage Interests">
+      <div className="container mx-auto px-4 py-8 max-w-xl">
+        <h1 className="text-2xl font-bold mb-4">Manage Interest Topics</h1>
+        <form onSubmit={addTopic} className="flex space-x-2 mb-6">
+          <input
+            type="text"
+            className="flex-1 border rounded px-2 py-1"
+            value={newTopic}
+            onChange={e => setNewTopic(e.target.value)}
+            placeholder="Add topic (e.g. AAPL, Bitcoin)"
+          />
+          <button
+            type="submit"
+            className="bg-blue-600 text-white px-4 rounded"
+          >
+            Add
+          </button>
+        </form>
+        <ul className="space-y-2">
+          {topics.map(t => (
+            <li key={t} className="flex justify-between items-center border-b pb-1">
+              <span>{t}</span>
+              <button
+                onClick={() => removeTopic(t)}
+                className="text-red-600 hover:underline"
+              >
+                Delete
+              </button>
+            </li>
+          ))}
+          {!topics.length && <li className="text-gray-500">No topics added.</li>}
+        </ul>
+      </div>
+    </MainLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- add hidden interest management UI in `manage-interests` page
- implement `/api/interests` for reading/writing interest topics in an S3 bucket
- document S3 environment variables
- mention hidden admin page in README
- include `@aws-sdk/client-s3` dependency

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: Cannot find module '@aws-sdk/client-s3')*

------
https://chatgpt.com/codex/tasks/task_e_68489f7d0d38832f9def0910f3c95117